### PR TITLE
Added "Scenariomall" as an alternative to swedish translation of "scenario outline".

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -475,7 +475,7 @@
   feature: Egenskap
   background: Bakgrund
   scenario: Scenario
-  scenario_outline: Scenariomall
+  scenario_outline: Abstrakt Scenario|Scenariomall
   examples: Exempel
   given: "*|Givet"
   when: "*|När"


### PR DESCRIPTION
Currently "Scenario outline" is "Abstrakt scenario" in swedish. I have asked 5 people from various organizations if they understood what that means. Noone understood it but happily copy/pasted it when they were doing scenario outlines.

After explaining what a scenario outline was I asked them if "Scenariomall" (literal "scenario template") was a better translation and received a reply from 4 people that they agreed it was.

This update implements the new suggestion in i18n.yml by adding "Scenariomall" as an alternative.
