### PR TITLE
Tags above comments

### DIFF
--- a/features/feature_parser.feature
+++ b/features/feature_parser.feature
@@ -235,3 +235,17 @@ Feature: Gherkin Feature lexer
             | cucumbers |
       """
     Then there should be no parse errors
+
+  Scenario: Comments between tags Scenario titles
+    Given the following text is parsed:
+      """
+      Feature: Test
+
+        @tag
+        # Comment about tagged scenario
+        Scenario: Tag still works
+          Given some neat conditions
+          When I do stuff
+          Then I should see some cool results
+      """
+    Then there should be no parse errors

--- a/lib/gherkin/parser/meta.txt
+++ b/lib/gherkin/parser/meta.txt
@@ -1,5 +1,5 @@
  |         | feature | background | scenario | scenario_outline | examples | step  | row   | py_string | eof | comment | tag |
  | meta    | E       | E          | E        | E                | E        | E     | E     | E         | eof | comment | tag |
  | comment | pop()   | pop()      | pop()    | pop()            | pop()    | pop() | pop() | pop()     | eof | pop()   | tag |
- | tag     | pop()   | E          | pop()    | pop()            | pop()    | E     | E     | E         | E   | E       | tag |
+ | tag     | pop()   | E          | pop()    | pop()            | pop()    | E     | E     | E         | E   | comment | tag |
  | eof     | E       | E          | E        | E                | E        | E     | E     | E         | E   | E       | E   |


### PR DESCRIPTION
If there is a comment between a tag and the scenario title gherkin currently gives a syntax error. This makes it ignore the comment and run the scenario with the tag.

I ran into this the other day when adding a tag to a scenario that had some leading comments. It was more natural for me to put the tag before the comment than after so I thought it makes sense for gherkin to support that.
