### PR TITLE
Fixing C90 errors on Ubuntu Natty

### DIFF
--- a/ragel/lexer.c.rl.erb
+++ b/ragel/lexer.c.rl.erb
@@ -175,11 +175,12 @@ static VALUE rb_eGherkinLexingError;
   }
 
   action store_cell_content {
+    VALUE re_pipe, re_newline, re_backslash;
     VALUE con = ENCODED_STR_NEW(PTR_TO(content_start), LEN(content_start, p));
     rb_funcall(con, rb_intern("strip!"), 0);
-    VALUE re_pipe      = rb_reg_regcomp(rb_str_new2("\\\\\\|"));
-    VALUE re_newline   = rb_reg_regcomp(rb_str_new2("\\\\n"));
-    VALUE re_backslash = rb_reg_regcomp(rb_str_new2("\\\\\\\\"));
+    re_pipe      = rb_reg_regcomp(rb_str_new2("\\\\\\|"));
+    re_newline   = rb_reg_regcomp(rb_str_new2("\\\\n"));
+    re_backslash = rb_reg_regcomp(rb_str_new2("\\\\\\\\"));
     rb_funcall(con, rb_intern("gsub!"), 2, re_pipe,      rb_str_new2("|"));
     rb_funcall(con, rb_intern("gsub!"), 2, re_newline,   rb_str_new2("\n"));
     rb_funcall(con, rb_intern("gsub!"), 2, re_backslash, rb_str_new2("\\"));
@@ -192,6 +193,7 @@ static VALUE rb_eGherkinLexingError;
   }
 
   action end_feature {
+    int line;
     if (cs < lexer_first_final) {
       if (raise_lexer_error != NULL) {
         size_t count = 0;
@@ -212,6 +214,7 @@ static VALUE rb_eGherkinLexingError;
         newstr_val = rb_str_new(buff, len);
         newstr = RSTRING_PTR(newstr_val);
 
+
         for (count = 0; count < len; count++) {
           if(buff[count] == 10) {
             newstr[newstr_count] = '\0'; // terminate new string at first newline found
@@ -227,7 +230,7 @@ static VALUE rb_eGherkinLexingError;
           newstr_count++;
         }
 
-        int line = lexer->line_number;
+	line = lexer->line_number;
         lexer_init(lexer); // Re-initialize so we can scan again with the same lexer
         raise_lexer_error(newstr, line);
       }
@@ -246,10 +249,11 @@ static VALUE rb_eGherkinLexingError;
 static VALUE 
 unindent(VALUE con, int start_col)
 {
+  VALUE re;
   // Gherkin will crash gracefully if the string representation of start_col pushes the pattern past 32 characters
   char pat[32]; 
   snprintf(pat, 32, "^[\t ]{0,%d}", start_col); 
-  VALUE re = rb_reg_regcomp(rb_str_new2(pat));
+  re = rb_reg_regcomp(rb_str_new2(pat));
   rb_funcall(con, rb_intern("gsub!"), 2, re, rb_str_new2(""));
 
   return Qnil;
@@ -275,6 +279,7 @@ store_multiline_kw_con(VALUE listener, const char * event_name,
                       const char * at,         size_t length,
                       int current_line, int start_col)
 {
+  VALUE split;
   VALUE con = Qnil, kw = Qnil, name = Qnil, desc = Qnil;
 
   kw = ENCODED_STR_NEW(keyword_at, keyword_length);
@@ -282,7 +287,7 @@ store_multiline_kw_con(VALUE listener, const char * event_name,
 
   unindent(con, start_col);
   
-  VALUE split = rb_str_split(con, "\n");
+  split = rb_str_split(con, "\n");
 
   name = rb_funcall(split, rb_intern("shift"), 0);
   desc = rb_ary_join(split, rb_str_new2( "\n" ));
@@ -315,12 +320,14 @@ store_pystring_content(VALUE listener,
           const char *at, size_t length, 
           int current_line)
 {
+  VALUE re2;
+  VALUE unescape_escaped_quotes;
   VALUE con = ENCODED_STR_NEW(at, length);
 
   unindent(con, start_col);
 
-  VALUE re2 = rb_reg_regcomp(rb_str_new2("\r\\Z"));
-  VALUE unescape_escaped_quotes = rb_reg_regcomp(rb_str_new2("\\\\\"\\\\\"\\\\\""));
+  re2 = rb_reg_regcomp(rb_str_new2("\r\\Z"));
+  unescape_escaped_quotes = rb_reg_regcomp(rb_str_new2("\\\\\"\\\\\"\\\\\""));
   rb_funcall(con, rb_intern("sub!"), 2, re2, rb_str_new2(""));
   rb_funcall(con, rb_intern("gsub!"), 2, unescape_escaped_quotes, rb_str_new2("\"\"\""));
   rb_funcall(listener, rb_intern("py_string"), 2, con, INT2FIX(current_line));
@@ -359,9 +366,10 @@ static VALUE CLexer_alloc(VALUE klass)
 
 static VALUE CLexer_init(VALUE self, VALUE listener)
 {
+  lexer_state *lxr; 
   rb_iv_set(self, "@listener", listener);
   
-  lexer_state *lxr = NULL;
+  lxr = NULL;
   DATA_GET(self, lexer_state, lxr);
   lexer_init(lxr);
   
@@ -370,16 +378,20 @@ static VALUE CLexer_init(VALUE self, VALUE listener)
 
 static VALUE CLexer_scan(VALUE self, VALUE input)
 {
+  VALUE input_copy;
+  char *data;
+  size_t len;
   VALUE listener = rb_iv_get(self, "@listener");
 
-  lexer_state *lexer = NULL;
+  lexer_state *lexer;
+  lexer = NULL;
   DATA_GET(self, lexer_state, lexer);
 
-  VALUE input_copy = rb_str_dup(input);
+  input_copy = rb_str_dup(input);
 
   rb_str_append(input_copy, rb_str_new2("\n%_FEATURE_END_%"));
-  char *data = RSTRING_PTR(input_copy);
-  size_t len = RSTRING_LEN(input_copy);
+  data = RSTRING_PTR(input_copy);
+  len = RSTRING_LEN(input_copy);
   
   if (len == 0) { 
     rb_raise(rb_eGherkinLexingError, "No content to lex.");


### PR DESCRIPTION
I was getting some errors like this when installing on an Ubuntu Natty box:

<pre>
compiling gherkin_lexer_ar.c
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl: In function ‘unindent’:
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:252:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl: In function ‘store_multiline_kw_con’:
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:285:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl: In function ‘store_pystring_content’:
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:322:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl: In function ‘CLexer_init’:
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:364:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl: In function ‘CLexer_scan’:
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:378:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:381:3: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:180:5: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:230:9: error: ISO C90 forbids mixed declarations and code
/Users/ahellesoy/scm/gherkin/tasks/../ragel/i18n/ar.c.rl:230:9: error: ISO C90 forbids mixed declarations and code
</pre>


Caveat: I'm having difficulties getting a kosher environment for testing. Even though bundler is installed, I get this before `bundle exec rspec` is run:

<pre>
/home/colin/.rvm/rubies/ruby-head/lib/ruby/1.9.1/rubygems.rb:761:in `report_activate_error': Could not find RubyGem bundler (>= 0) (Gem::LoadError)
    from /home/colin/.rvm/rubies/ruby-head/lib/ruby/1.9.1/rubygems.rb:219:in `activate'
    from /home/colin/.rvm/rubies/ruby-head/lib/ruby/1.9.1/rubygems.rb:1064:in `gem'
    from /home/colin/.rvm/gems/ruby-head@cucumber/bin/bundle:18:in `<main>'
rake aborted!
</pre>


However, when I try to install the gem using bundler in my actual application (colindean/plas) with the Gemfile pointing to my github repo, the gem installs fine.
