### PR TITLE
Bump json version to 1.5.1 to fix Windows fat binary

### DIFF
--- a/gherkin.gemspec
+++ b/gherkin.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency('rake-compiler', '~> 0.7.5')
   end
 
-  s.add_dependency('json', '>= 1.4.6')
+  s.add_dependency('json', '>= 1.5.1')
 
   s.add_development_dependency('cucumber', '>= 0.10.0')
   s.add_development_dependency('rake', '>= 0.8.7')


### PR DESCRIPTION
The json gem author has finally updated json to create a fat binary on Windows which means it installs correctly on Windows for both 1.8 and 1.9 users. This will resolve issue #80: https://github.com/aslakhellesoy/gherkin/issues#issue/80 and will make using cucumber on Windows much less painful.
