### PR TITLE
Corrected Russian translations

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -446,11 +446,11 @@
 "ru":
   name: Russian
   native: русский
-  feature: Функционал|Фича
-  background: Предыстория
+  feature: Функция|Функционал|Свойство
+  background: Предыстория|Контекст
   scenario: Сценарий
   scenario_outline: Структура сценария
-  examples: Значения
+  examples: Примеры
   given: "*|Допустим|Дано|Пусть"
   when: "*|Если|Когда"
   then: "*|То|Тогда"


### PR DESCRIPTION
I wasn't happy with a word "фича" that is not a word in Russian, it's just a programmers' jargon. I propose to change it to "функция" and double-checked it in an Internet Russian language community (http://community.livejournal.com/pishu_pravilno/4316739.html). In addition I added a new synonym to "background" definition and changed "example" translation from "значения" (values) to "примеры" (examples).
