### PR TITLE
Don't use -Werror in production code

### DIFF
--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -72,7 +72,7 @@ langs.each do |i18n|
         io.write(<<-EOF)
 require 'mkmf'
 CONFIG['warnflags'].gsub!(/-Wshorten-64-to-32/, '') if CONFIG['warnflags']
-$CFLAGS << ' -O0 -Wall -Werror' if CONFIG['CC'] =~ /gcc/
+$CFLAGS << ' -O0 -Wall' if CONFIG['CC'] =~ /gcc/
 dir_config("gherkin_lexer_#{i18n.underscored_iso_code}")
 have_library("c", "main")
 create_makefile("gherkin_lexer_#{i18n.underscored_iso_code}")


### PR DESCRIPTION
Using -Werror will break compilation when new versions of gcc are
introduced since new warnings are added for every new version.

I got bug reports for Gentoo that this breaks with gcc 4.6 specifically although I have not confirmed that yet. You may want to solve this in a different way so that it is easy to add -Werror in development mode.
