### PR TITLE
If you .gitignore the native libs, they'll be missing from a committed bundle.

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,4 +1,1 @@
 *.bundle
-*.dll
-*.so
-*.jar


### PR DESCRIPTION
Bundles committed to git for deployment that included gherkin were missing the native libs. If you don't want to commit them to the gherkin project repo, have 'rake clean' take care of it.
