### PR TITLE
Replace String#trimRight() call which is not supported by Opera with String#replace() (close #115)

### DIFF
--- a/ragel/lexer.js.rl.erb
+++ b/ragel/lexer.js.rl.erb
@@ -181,7 +181,7 @@ Lexer.prototype.unindent = function(startcol, text) {
 
 Lexer.prototype.store_keyword_content = function(event, data, p, eof) {
   var end_point = (!this.next_keyword_start || (p == eof)) ? p : this.next_keyword_start;
-  var content = this.unindent(this.start_col + 2, this.bytesToString(data.slice(this.content_start, end_point))).trimRight();
+  var content = this.unindent(this.start_col + 2, this.bytesToString(data.slice(this.content_start, end_point))).replace(/\s+$/,"");
   var content_lines = content.split("\n")
   var name = content_lines.shift() || "";
   name = name.trim();


### PR DESCRIPTION
This fixes #115, Gherkin is now running fine on Chrome, FF, Safari and Opera.
