### PR TITLE
Exclude .gitignore files from packaged gem

### DIFF
--- a/gherkin.gemspec
+++ b/gherkin.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |s|
     s.add_development_dependency('rake-compiler', '>= 0.7.9')
   end
 
+  s.files -= Dir['**/.gitignore']
+
   s.add_dependency('json', '>= 1.4.6')
 
   s.add_development_dependency('cucumber', '>= 1.0.2')


### PR DESCRIPTION
This is the alternative solution to the problem that prompted issue/pull request #111. The solution there was to start committing build artifacts, which is a bad idea. This just excludes the .gitignore files from packaged gems.
