### PR TITLE
Given keyword in portuguese

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -438,7 +438,7 @@
   scenario: Cenário|Cenario
   scenario_outline: Esquema do Cenário|Esquema do Cenario
   examples: Exemplos
-  given: "*|Dado"
+  given: "*|Dado|Dada|Dados|Dadas"
   when: "*|Quando"
   then: "*|Então|Entao"
   and: "*|E"


### PR DESCRIPTION
Added variations of the Given keyword in portuguese (gender and number variations).

Before, there was only "Dado". I added "Dada", "Dados" and "Dadas", so it could conform, for instance, with the following steps:

Dado o seguinte usuário
Dada uma nova tarefa
Dados os seguintes usuários
Dadas as seguintes tarefas
