### PR TITLE
Added plural and feminine to Given particle in Italian

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -321,7 +321,7 @@
   scenario: Scenario
   scenario_outline: Schema dello scenario
   examples: Esempi
-  given: "*|Dato"
+  given: "*|Dato|Data|Dati|Date"
   when: "*|Quando"
   then: "*|Allora"
   and: "*|E"


### PR DESCRIPTION
Currenty Given is translated in Italian for the only singular masculine form. Plural and feminine forms have been added to i18n.yml to support all possible declinations of "Given" in Italian.
