### PR TITLE
Fixed order of keywords for Czech

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -89,7 +89,7 @@
   given: "*|Pokud"
   when: "*|Když"
   then: "*|Pak"
-  and: "*|A|A také"
+  and: "*|A také|A"
   but: "*|Ale"
 "da":
   name: Danish


### PR DESCRIPTION
Fixed order of `and` keyword Czech translations. Before this PR, second keyword will not match, as `A` will always do.
