### PR TITLE
Expose AnsiEscapes methods on the class level as well, for easy calling without inclusion

### DIFF
--- a/lib/gherkin/formatter/ansi_escapes.rb
+++ b/lib/gherkin/formatter/ansi_escapes.rb
@@ -90,6 +90,8 @@ module Gherkin
       def up(n)
         "\e[#{n}A"
       end
+
+      extend self
     end
   end
 end

--- a/spec/gherkin/formatter/ansi_escapes_spec.rb
+++ b/spec/gherkin/formatter/ansi_escapes_spec.rb
@@ -4,16 +4,29 @@ require 'gherkin/formatter/ansi_escapes'
 module Gherkin
   module Formatter
     describe AnsiEscapes do
-      include Gherkin::Formatter::AnsiEscapes
+      describe "instance methods" do
+        include AnsiEscapes
 
-      it "failed should be red" do
-        failed.should == "\e[31m"
+        it "failed should be red" do
+          failed.should == "\e[31m"
+        end
+
+        it "failed_arg should be red bold" do
+          failed_arg.should == "\e[31m\e[1m"
+        end
       end
 
-      it "failed arg should be red bold" do
-        failed_arg.should == "\e[31m\e[1m"
-      end
+      describe "class methods" do
+        subject { AnsiEscapes }
 
+        it "failed should be red" do
+          subject.failed.should == "\e[31m"
+        end
+
+        it "failed_arg should be red bold" do
+          subject.failed_arg.should == "\e[31m\e[1m"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is a step toward fixing cucumber/cucumber#219 by exposing the AnsiEscapes methods at the module-level as well.
