### PR TITLE
Variants of keywords in Portuguese

### DIFF
--- a/lib/gherkin/i18n.yml
+++ b/lib/gherkin/i18n.yml
@@ -432,11 +432,11 @@
 "pt":
   name: Portuguese
   native: português
-  background: Contexto
-  feature: Funcionalidade
+  background: Contexto|Cenário de Fundo|Cenario de Fundo|Fundo
+  feature: Funcionalidade|Característica|Caracteristica
   scenario: Cenário|Cenario
-  scenario_outline: Esquema do Cenário|Esquema do Cenario
-  examples: Exemplos
+  scenario_outline: Esquema do Cenário|Esquema do Cenario|Delineação do Cenário|Delineacao do Cenario
+  examples: Exemplos|Cenários|Cenarios
   given: "*|Dado|Dada|Dados|Dadas"
   when: "*|Quando"
   then: "*|Então|Entao"

--- a/spec/gherkin/fixtures/i18n_pt1.feature
+++ b/spec/gherkin/fixtures/i18n_pt1.feature
@@ -1,0 +1,44 @@
+# language: pt
+Funcionalidade: Reconhece "Funcionalidade"
+
+  Contexto: Reconhece "Contexto"
+
+  Cenário: Reconhece "Cenário" com acento
+
+  Cenario: Reconhece "Cenário" sem acento
+    
+  Esquema do Cenário: Reconhece "Esquema do Cenário" com acento
+    Dado que <Valor> é um valor e que reconhece "Dado";
+    Dada a afirmação de que reconhece "Dada";
+    Dados os factos acima e ainda que reconhece "Dados";
+    Dadas as afirmações acima e ainda que reconhece "Dadas";
+    Quando reconhece "Quando";
+    Então também reconhece "Então" com acento e
+    Entao também reconhece "Então" sem acento;
+    E reconhece "E";
+    Mas também reconhece "Mas".
+
+    Exemplos: Reconhece "Exemplos"
+      | Valor |
+      |     1 |
+
+  Esquema do Cenario: Reconhece "Esquema do Cenário" sem acento
+    Dado que <Valor> é um valor;
+
+    Cenários: Reconhece "Cenários" com acento
+      | Valor |
+      |     1 |
+
+  Delineação do Cenário: Reconhece "Delineação do Cenário" com acento
+    Dado que <Valor> é um valor;
+
+    Cenarios: Reconhece "Cenários" sem acento
+      | Valor |
+      |     1 |
+
+  Delineacao do Cenario:  Reconhece "Delineação do Cenário" sem acento
+    Dado que <Valor> é um valor;
+
+    Exemplos: Reconhece "Exemplos"
+      | Valor |
+      |     1 |

--- a/spec/gherkin/fixtures/i18n_pt2.feature
+++ b/spec/gherkin/fixtures/i18n_pt2.feature
@@ -1,0 +1,4 @@
+# language: pt
+Característica: Reconhece "Característica" com acento
+
+  Cenário de Fundo: Reconhece "Cenário de Fundo" com acento

--- a/spec/gherkin/fixtures/i18n_pt3.feature
+++ b/spec/gherkin/fixtures/i18n_pt3.feature
@@ -1,0 +1,4 @@
+# language: pt
+Caracteristica: Reconhece "Característica" sem acento
+
+  Cenario de Fundo: Reconhece "Cenário de Fundo" sem acento

--- a/spec/gherkin/fixtures/i18n_pt4.feature
+++ b/spec/gherkin/fixtures/i18n_pt4.feature
@@ -1,0 +1,4 @@
+# language: pt
+Característica: Reconhece "Característica" com acento
+
+  Fundo: Reconhece "Fundo"

--- a/spec/gherkin/i18n_spec.rb
+++ b/spec/gherkin/i18n_spec.rb
@@ -76,6 +76,80 @@ module Gherkin
         ]
       end
 
+      it "should recognize keywords in Portuguese (1st variant)" do
+        lexer = Gherkin::Lexer::I18nLexer.new(@listener, false)
+        scan_file(lexer, "i18n_pt1.feature")
+        @listener.to_sexp.should == [
+          [:comment, "# language: pt", 1],
+          [:feature, "Funcionalidade", "Reconhece \"Funcionalidade\"", "", 2],
+          [:background, "Contexto", "Reconhece \"Contexto\"", "", 4],
+          [:scenario, "Cenário", "Reconhece \"Cenário\" com acento", "", 6],
+          [:scenario, "Cenario", "Reconhece \"Cenário\" sem acento", "", 8],
+          [:scenario_outline, "Esquema do Cenário", "Reconhece \"Esquema do Cenário\" com acento", "", 10],
+          [:step, "Dado ", "que <Valor> é um valor e que reconhece \"Dado\";", 11],
+          [:step, "Dada ", "a afirmação de que reconhece \"Dada\";", 12],
+          [:step, "Dados ", "os factos acima e ainda que reconhece \"Dados\";", 13],
+          [:step, "Dadas ", "as afirmações acima e ainda que reconhece \"Dadas\";", 14],
+          [:step, "Quando ", "reconhece \"Quando\";", 15],
+          [:step, "Então ", "também reconhece \"Então\" com acento e", 16],
+          [:step, "Entao ", "também reconhece \"Então\" sem acento;", 17],
+          [:step, "E ", "reconhece \"E\";", 18],
+          [:step, "Mas ", "também reconhece \"Mas\".", 19],
+          [:examples, "Exemplos", "Reconhece \"Exemplos\"", "", 21],
+          [:row, ["Valor"], 22],
+          [:row, ["1"], 23],
+          [:scenario_outline, "Esquema do Cenario", "Reconhece \"Esquema do Cenário\" sem acento", "", 25],
+          [:step, "Dado ", "que <Valor> é um valor;", 26],
+          [:examples, "Cenários", "Reconhece \"Cenários\" com acento", "", 28],
+          [:row, ["Valor"], 29],
+          [:row, ["1"], 30],
+          [:scenario_outline, "Delineação do Cenário", "Reconhece \"Delineação do Cenário\" com acento", "", 32],
+          [:step, "Dado ", "que <Valor> é um valor;", 33],
+          [:examples, "Cenarios", "Reconhece \"Cenários\" sem acento", "", 35],
+          [:row, ["Valor"], 36],
+          [:row, ["1"], 37],
+          [:scenario_outline, "Delineacao do Cenario", "Reconhece \"Delineação do Cenário\" sem acento", "", 39],
+          [:step, "Dado ", "que <Valor> é um valor;", 40],
+          [:examples, "Exemplos", "Reconhece \"Exemplos\"", "", 42],
+          [:row, ["Valor"], 43],
+          [:row, ["1"], 44],
+          [:eof]
+        ]
+      end
+
+      it "should recognize keywords in Portuguese (2nd variant)" do
+        lexer = Gherkin::Lexer::I18nLexer.new(@listener, false)
+        scan_file(lexer, "i18n_pt2.feature")
+        @listener.to_sexp.should == [
+          [:comment, "# language: pt", 1],
+          [:feature, "Característica", "Reconhece \"Característica\" com acento", "", 2],
+          [:background, "Cenário de Fundo", "Reconhece \"Cenário de Fundo\" com acento", "", 4],
+          [:eof]
+        ]
+      end
+
+      it "should recognize keywords in Portuguese (3rd variant)" do
+        lexer = Gherkin::Lexer::I18nLexer.new(@listener, false)
+        scan_file(lexer, "i18n_pt3.feature")
+        @listener.to_sexp.should == [
+          [:comment, "# language: pt", 1],
+          [:feature, "Caracteristica", "Reconhece \"Característica\" sem acento", "", 2],
+          [:background, "Cenario de Fundo", "Reconhece \"Cenário de Fundo\" sem acento", "", 4],
+          [:eof]
+        ]
+      end
+
+      it "should recognize keywords in Portuguese (4th variant)" do
+        lexer = Gherkin::Lexer::I18nLexer.new(@listener, false)
+        scan_file(lexer, "i18n_pt4.feature")
+        @listener.to_sexp.should == [
+          [:comment, "# language: pt", 1],
+          [:feature, "Característica", "Reconhece \"Característica\" com acento", "", 2],
+          [:background, "Fundo", "Reconhece \"Fundo\"", "", 4],
+          [:eof]
+        ]
+      end
+
       describe 'keywords' do
         it "should have code keywords without space, comma, exclamation or apostrophe" do
           ['Avast', 'Akkor', 'Etantdonné', 'Lorsque', '假設'].each do |code_keyword|


### PR DESCRIPTION
I've added a few variants of the keywords in Portuguese. Since I did not change any of the keywords for steps, I thing the change will not cause problems to existing features. This, however, cannot be ruled out entirely. I've also added a few tests.

**Changes**

Feature:
- Was "Funcionalidade"
- Added "Característica"
- Rationale: "Funcionalidade", meaning "functionality", does not convey the meaning of "feature" very well.

Background:
- Was "Contexto"
- Added "Cenário de Fundo" and "Fundo"
- Rationale: The new alternatives are closer to the theatre metaphor than "contexto" ("context").

Scenario Outline:
- Was "Esquema do Cenário"
- Added "Delineação do Cenário"
- Rationale: The new alternative is closer to the theatre metaphor than "Esquema" ("scheme").

Examples:
- Was "Exemplos"
- Added "Cenários"
- Rationale: For consistency with the two alternatives in English.
