### PR TITLE
Fix for Australian language support

### DIFF
--- a/lib/gherkin/i18n.json
+++ b/lib/gherkin/i18n.json
@@ -128,16 +128,16 @@
 	"en-au": {
 	  "name": "Australian",
 	  "native": "Australian",
-	  "feature": "Crikey",
-	  "background": "Background",
-	  "scenario": "Mate",
-	  "scenario_outline": "Blokes",
-	  "examples": "Cobber",
-	  "given": "*|Ya know how",
-	  "when": "*|When",
-	  "then": "*|Ya gotta",
-	  "and": "*|N",
-	  "but": "*|Cept"
+	  "feature": "Pretty much",
+	  "background": "First off",
+	  "scenario": "Awww, look mate",
+	  "scenario_outline": "Reckon it's like",
+	  "examples": "You'll wanna",
+	  "given": "*|Y'know",
+	  "when": "*|It's just unbelievable",
+	  "then": "*|But at the end of the day I reckon",
+	  "and": "*|Too right",
+	  "but": "*|Yeah nah"
 	},
 	"en-lol": {
 	  "name": "LOLCAT",


### PR DESCRIPTION
The previous Australian language support did not make grammatical sense when used in scenarios. I have amended it to provide a more authentic experience. For example:

Awww, look mate: I just wanna login to me website
  Y'know I've got to the login page
  It's just unbelievable I fill in me form
  Too right I click the save button
  But at the end of the day, I reckon I should be logged in
