### PR TITLE
Add duration value to json formatter

### DIFF
--- a/lib/gherkin/formatter/json_formatter.rb
+++ b/lib/gherkin/formatter/json_formatter.rb
@@ -63,7 +63,7 @@ module Gherkin
       end
       
       def append_duration(timestamp)
-      	#check to make sure result exists (scenario outlines do not have results!)
+      	#check to make sure result exists (scenario outlines do not have results yet)
       	if !@current_step_or_hook['result'].nil?
         	#convert to nanoseconds
         	timestamp = timestamp * 1000000000


### PR DESCRIPTION
Added new method that is called from the after_step in Cucumber.  Duration value is appended to the result hash.
