### PR TITLE
BugFix: The "line" attribute got lost when rubifying Java ArrayList objects.

### DIFF
--- a/lib/gherkin/rubify.rb
+++ b/lib/gherkin/rubify.rb
@@ -5,14 +5,21 @@ module Gherkin
       # This is especially important to convert java.util.List coming
       # from Java and back to a Ruby Array.
       def rubify(o)
-        case(o)
-        when Java.java.util.Collection, Array
-          o.map{|e| rubify(e)}
-        when Java.gherkin.formatter.model.DocString
-          require 'gherkin/formatter/model'
-          Formatter::Model::DocString.new(o.content_type, o.value, o.line)
-        else
-          o
+        case (o)
+          when Java.java.util.Collection, Array
+            rubified_array = o.map{ |e| rubify(e) }
+            if o.respond_to?(:line)
+              class << rubified_array
+                attr_accessor :line
+              end
+              rubified_array.line = o.line
+            end
+            rubified_array
+          when Java.gherkin.formatter.model.DocString
+            require 'gherkin/formatter/model'
+            Formatter::Model::DocString.new(o.content_type, o.value, o.line)
+          else
+            o
         end
       end
     else

--- a/spec/gherkin/rubify_spec.rb
+++ b/spec/gherkin/rubify_spec.rb
@@ -1,0 +1,23 @@
+#encoding: utf-8
+if defined?(JRUBY_VERSION)
+  require 'spec_helper'
+  include Gherkin::Rubify
+
+  module Gherkin
+    module Rubify
+      describe "rubify" do
+        before do
+          @java_collection = [mock("Java.java.util.ArrayList")]
+          @java_collection.stub(:===).and_return(Java.java.util.Collection)
+          @java_collection.stub(:line).and_return(15)
+          @rubified_array = rubify(@java_collection)
+        end
+
+        it "should keep the line number attribute from Java object" do
+          @rubified_array.should respond_to(:line)
+          @rubified_array.line.should == 15
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi Aslak,

We were having issue setting up Cucumber re-run, because the line number was recorded as '-1'  for Scenario Outline. We're using jRuby 1.6.7, 1.6.8, and 1.7.0.

It's the exact issue in the issue log [#174](https://github.com/cucumber/cucumber/issues/174). 

``` ruby
Scenario Outline: User should see the correct formatted address
    Given I am on the translation page
    When I fill in the "address" field with "<Search query>"
    And I click "Translate"
    Then I should see "<Formatted address>" in the "address" field
  Examples:
    | Search query                   | Formatted address                               |
    | 100 george street sydney       | 100 George Street, Sydney, New South Wales      |
    | 100 miller street north sydney | 100 Miller St, North Sydney NSW 2060, Australia |
```

The above scenario outline failed on the first example, and the line number is 8. In the output file, we're expecting the following:

``` ruby
features/translater.feature:8
```

But instead we've got:

``` ruby
features/translater.feature:-1
```

When tracing down the line, I found the following line of code throwing 'NoMethod' exception, thus '-1' gets returned (cucumber/ast/table.rb):

``` ruby
      def create_cell_matrix(raw) #:nodoc:
        @cell_matrix = raw.map do |raw_row|
          line = raw_row.line rescue -1      # <<<<<<<<< This is where '-1' comes from.
          raw_row.map do |raw_cell|
            new_cell(raw_cell, line)
          end
        end
      end
```

Traced down a bit further, we found in Gherkin, Java objects get translated into Ruby object:

``` ruby
      def rubify(o)
        case(o)
        when Java.java.util.Collection, Array
          o.map{|e| rubify(e)}           # <<<<<<<<<< This line here translates the Java object into Ruby Array.
        when Java.gherkin.formatter.model.DocString
          require 'gherkin/formatter/model'
          Formatter::Model::DocString.new(o.content_type, o.value, o.line)
        else
          o
        end
      end
```

When Java Collection object gets translated into Ruby Array object, the 'line' attribute gets lost here.

I've put in a fix with test in this pull request. Please let me know of any questions. 

Thanks,
Felix
