### PR TITLE
Use multi_json instead of json gem

### DIFF
--- a/examples/parse_and_output_json.rb
+++ b/examples/parse_and_output_json.rb
@@ -1,7 +1,7 @@
 require 'gherkin/parser/parser'
 require 'gherkin/formatter/json_formatter'
 require 'stringio'
-require 'json'
+require 'multi_json'
 
 # This example reads a couple of features and outputs them as JSON.
 
@@ -16,4 +16,4 @@ sources.each do |s|
 end
 
 formatter.done
-puts JSON.pretty_generate(JSON.parse(io.string))
+puts MultiJson.dump(MultiJson.load(io.string), :pretty => true)

--- a/features/.cucumber/stepdefs.json
+++ b/features/.cucumber/stepdefs.json
@@ -136,7 +136,7 @@
     ]
   },
   {
-    "file_colon_line": "features/step_definitions/json_parser_steps.rb:5",
+    "file_colon_line": "features/step_definitions/json_parser_steps.rb:6",
     "flags": "",
     "source": "^a PrettyFormatter$",
     "steps": [
@@ -144,7 +144,7 @@
     ]
   },
   {
-    "file_colon_line": "features/step_definitions/json_parser_steps.rb:10",
+    "file_colon_line": "features/step_definitions/json_parser_steps.rb:11",
     "flags": "",
     "source": "^a JSON lexer$",
     "steps": [
@@ -152,7 +152,7 @@
     ]
   },
   {
-    "file_colon_line": "features/step_definitions/json_parser_steps.rb:14",
+    "file_colon_line": "features/step_definitions/json_parser_steps.rb:15",
     "flags": "",
     "source": "^the following JSON is parsed:$",
     "steps": [
@@ -165,7 +165,7 @@
     ]
   },
   {
-    "file_colon_line": "features/step_definitions/json_parser_steps.rb:18",
+    "file_colon_line": "features/step_definitions/json_parser_steps.rb:19",
     "flags": "",
     "source": "^the outputted text should be:$",
     "steps": [

--- a/features/step_definitions/json_formatter_steps.rb
+++ b/features/step_definitions/json_formatter_steps.rb
@@ -16,13 +16,13 @@ Given /^a JSON formatter$/ do
 end
 
 Then /^the outputted JSON should be:$/ do |expected_json|
-  require 'json'
+  require 'multi_json'
   @formatter.done
   actual_json = @out.string
   puts actual_json
-  puts JSON.pretty_generate(JSON.parse(actual_json))
-  expected = JSON.parse(expected_json)
-  actual   = JSON.parse(actual_json)
+  puts MultiJson.dump(MultiJson.load(actual_json), :pretty => true)
+  expected = MultiJson.load(expected_json)
+  actual   = MultiJson.load(actual_json)
   actual.should == expected
 end
 

--- a/features/step_definitions/json_parser_steps.rb
+++ b/features/step_definitions/json_parser_steps.rb
@@ -1,6 +1,7 @@
 require 'stringio'
 require 'gherkin/formatter/pretty_formatter'
 require 'gherkin/json_parser'
+require 'multi_json'
 
 Given /^a PrettyFormatter$/ do
   @io = StringIO.new
@@ -12,7 +13,7 @@ Given /^a JSON lexer$/ do
 end
 
 Given /^the following JSON is parsed:$/ do |text|
-  @json_parser.parse(JSON.pretty_generate(JSON.parse(text)))
+  @json_parser.parse(MultiJson.dump(MultiJson.load(text), :pretty => true))
 end
 
 Then /^the outputted text should be:$/ do |expected_text|

--- a/gherkin.gemspec
+++ b/gherkin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   #
   # Repeat these step for cucumber (swap `cucumber` with `gherkin`).
   #
-  # When both are building OK, do a `bundle exec rake install` in both cucumber and gherkin projects, revert the changes in the first 2 steps 
+  # When both are building OK, do a `bundle exec rake install` in both cucumber and gherkin projects, revert the changes in the first 2 steps
   # and release both projects. Do this for both ruby 1.8.7, ruby 1.9.3 and jruby.
   #
   s.version     = "2.11.6"
@@ -36,11 +36,11 @@ Gem::Specification.new do |s|
   s.files -= Dir['lib/**/*.dll']
   s.files -= Dir['lib/**/*.bundle']
   s.files -= Dir['lib/**/*.so']
-  
+
   if ENV['GEM_PLATFORM']
     puts "GEM_PLATFORM:#{ENV['GEM_PLATFORM']}"
   end
-  s.platform = ENV['GEM_PLATFORM'] if ENV['GEM_PLATFORM'] 
+  s.platform = ENV['GEM_PLATFORM'] if ENV['GEM_PLATFORM']
   case s.platform.to_s
   when /java/
     s.files += Dir['lib/*.jar']
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   end
   s.files -= Dir['**/.gitignore']
 
-  s.add_runtime_dependency('json', '>= 1.7.6')
+  s.add_runtime_dependency('multi_json', '~> 1.3')
 
   s.add_development_dependency('cucumber', '>= 1.2.1')
   s.add_development_dependency('rake', '>= 10.0.3')

--- a/lib/gherkin/i18n.rb
+++ b/lib/gherkin/i18n.rb
@@ -1,6 +1,6 @@
-require 'json'
 require 'gherkin/rubify'
 require 'gherkin/native'
+require 'multi_json'
 
 module Gherkin
   class I18n
@@ -11,7 +11,7 @@ module Gherkin
     FEATURE_ELEMENT_KEYS = %w{feature background scenario scenario_outline examples}
     STEP_KEYWORD_KEYS    = %w{given when then and but}
     KEYWORD_KEYS         = FEATURE_ELEMENT_KEYS + STEP_KEYWORD_KEYS
-    LANGUAGES            = JSON.parse(File.open(File.dirname(__FILE__) + '/i18n.json', 'r:utf-8').read)
+    LANGUAGES            = MultiJson.load(File.open(File.dirname(__FILE__) + '/i18n.json', 'r:utf-8').read)
 
     class << self
       include Rubify
@@ -30,7 +30,7 @@ module Gherkin
       # there is typically a code generation tool to generate regular expressions for recognising the
       # various I18n translations of Gherkin's keywords.
       #
-      # The +keywords+ arguments can be one of <tt>:feature</tt>, <tt>:background</tt>, <tt>:scenario</tt>, 
+      # The +keywords+ arguments can be one of <tt>:feature</tt>, <tt>:background</tt>, <tt>:scenario</tt>,
       # <tt>:scenario_outline</tt>, <tt>:examples</tt>, <tt>:step</tt>.
       def keyword_regexp(*keywords)
         unique_keywords = all.map do |i18n|
@@ -42,7 +42,7 @@ module Gherkin
             end
           end
         end
-        
+
         unique_keywords.flatten.compact.map{|kw| kw.to_s}.sort.reverse.uniq.join('|').gsub(/\*/, '\*')
       end
 
@@ -150,14 +150,14 @@ module Gherkin
       gherkin_keyword_table = KEYWORD_KEYS.map do |key|
         Formatter::Model::Row.new([], [key, keywords(key).map{|keyword| %{"#{keyword}"}}.join(', ')], nil)
       end
-      
+
       code_keyword_table = STEP_KEYWORD_KEYS.map do |key|
         code_keywords = keywords(key).reject{|keyword| keyword == '* '}.map do |keyword|
           %{"#{self.class.code_keyword_for(keyword)}"}
         end.join(', ')
         Formatter::Model::Row.new([], ["#{key} (code)", code_keywords], nil)
       end
-      
+
       pf.table(gherkin_keyword_table + code_keyword_table)
       io.string
     end

--- a/lib/gherkin/json_parser.rb
+++ b/lib/gherkin/json_parser.rb
@@ -1,8 +1,8 @@
-require 'json'
-require 'gherkin/formatter/model'
-require 'gherkin/formatter/argument'
-require 'gherkin/native'
 require 'base64'
+require 'gherkin/formatter/argument'
+require 'gherkin/formatter/model'
+require 'gherkin/native'
+require 'multi_json'
 
 module Gherkin
   class JSONParser
@@ -17,7 +17,7 @@ module Gherkin
     # Parse a gherkin object +o+, which can either be a JSON String,
     # or a Hash (from a parsed JSON String).
     def parse(o)
-      o = JSON.parse(o) if String === o
+      o = MultiJson.load(o) if String === o
 
       o.each do |f|
         @formatter.uri(f['uri'])

--- a/spec/gherkin/formatter/json_formatter_spec.rb
+++ b/spec/gherkin/formatter/json_formatter_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
-require 'stringio'
 require 'gherkin/formatter/json_formatter'
 require 'gherkin/formatter/model'
+require 'multi_json'
+require 'stringio'
 
 module Gherkin
   module Formatter
@@ -25,7 +26,7 @@ module Gherkin
 
         f.eof
         f.done
-        
+
         expected = %{
           [
             {
@@ -85,7 +86,7 @@ module Gherkin
             }
           ]
         }
-        JSON.parse(expected).should == JSON.parse(io.string)
+        MultiJson.load(expected).should == MultiJson.load(io.string)
       end
     end
   end

--- a/spec/gherkin/json_parser_spec.rb
+++ b/spec/gherkin/json_parser_spec.rb
@@ -3,9 +3,10 @@ require 'stringio'
 require 'spec_helper'
 require 'gherkin/json_parser'
 require 'gherkin/formatter/json_formatter'
+require 'multi_json'
 
 module Gherkin
-  describe JSONParser do 
+  describe JSONParser do
 
     def check_json(json)
       io = StringIO.new
@@ -13,8 +14,8 @@ module Gherkin
       p = JSONParser.new(f, f)
       p.parse(json)
       f.done
-      expected = JSON.parse(json)
-      actual   = JSON.parse(io.string)
+      expected = MultiJson.load(json)
+      actual   = MultiJson.load(io.string)
 
       begin
         actual.should == expected
@@ -34,10 +35,10 @@ module Gherkin
         {
           "id": "one",
           "uri": "test.feature",
-          "keyword": "Feature", 
-          "name": "One", 
-          "description": "", 
-          "line" : 3 
+          "keyword": "Feature",
+          "name": "One",
+          "description": "",
+          "line" : 3
         }
       ]})
     end
@@ -53,9 +54,9 @@ module Gherkin
               "line": 22
             }
           ],
-          "keyword": "Feature", 
-          "name": "One", 
-          "description": "", 
+          "keyword": "Feature",
+          "name": "One",
+          "description": "",
           "line": 3,
           "elements": [
             {


### PR DESCRIPTION
By specifying a runtime dependency on `multi_json` instead of the `json` gem, it gives more flexibility to the end-user to use whatever JSON library they prefer (falling back to `json` on Ruby 1.9 and `okjson` on Ruby 1.8). In addition to these two adapters, `multi_json` supports Oj, YAJL, NSJSONSerialization (MacRuby only), and gson.rb (JRuby only). This allows for greater performance and compatibility across different interpreters.

This change has already been applied to `cucumber` in https://github.com/cucumber/cucumber/pull/362.
