### PR TITLE
Add i18n support for en-old / Old English / Englisc

### DIFF
--- a/java/src/test/java/gherkin/I18nTest.java
+++ b/java/src/test/java/gherkin/I18nTest.java
@@ -21,7 +21,7 @@ public class I18nTest {
                 return i18n.getIsoCode();
             }
         });
-        assertEquals(asList("ar,bg,bm,ca,cs,cy-GB,da,de,en,en-Scouse,en-au,en-lol,en-pirate,en-tx,eo,es,et,fa,fi,fr,he,hi,hr,hu,id,is,it,ja,ko,lt,lu,lv,nl,no,pl,pt,ro,ru,sk,sr-Cyrl,sr-Latn,sv,tl,tr,tt,uk,uz,vi,zh-CN,zh-TW".split(",")), isoCodes);
+        assertEquals(asList("ar,bg,bm,ca,cs,cy-GB,da,de,en,en-Scouse,en-au,en-lol,en-old,en-pirate,en-tx,eo,es,et,fa,fi,fr,he,hi,hr,hu,id,is,it,ja,ko,lt,lu,lv,nl,no,pl,pt,ro,ru,sk,sr-Cyrl,sr-Latn,sv,tl,tr,tt,uk,uz,vi,zh-CN,zh-TW".split(",")), isoCodes);
     }
 
     @Test

--- a/lib/gherkin/i18n.json
+++ b/lib/gherkin/i18n.json
@@ -153,6 +153,20 @@
 	  "and": "*|AN",
 	  "but": "*|BUT"
 	},
+	"en-old": {
+	  "name": "Old English",
+	  "native": "Englisc",
+	  "feature": "Hwaet|Hwæt",
+	  "background": "Aer|Ær",
+	  "scenario": "Swa",
+	  "scenario_outline": "Swa hwaer swa|Swa hwær swa",
+	  "examples": "Se the|Se þe|Se ðe",
+	  "given": "*|Thurh|Þurh|Ðurh",
+	  "when": "*|Tha|Þa|Ða",
+	  "then": "*|Tha|Þa|Ða|Tha the|Þa þe|Ða ðe",
+	  "and": "*|Ond|7",
+	  "but": "*|Ac"
+	},
 	"en-pirate": {
 	  "name": "Pirate",
 	  "native": "Pirate",

--- a/spec/gherkin/i18n_spec.rb
+++ b/spec/gherkin/i18n_spec.rb
@@ -179,6 +179,7 @@ module Gherkin
       | en-Scouse | Scouse              | Scouse            |
       | en-au     | Australian          | Australian        |
       | en-lol    | LOLCAT              | LOLCAT            |
+      | en-old    | Old English         | Englisc           |
       | en-pirate | Pirate              | Pirate            |
       | en-tx     | Texan               | Texan             |
       | eo        | Esperanto           | Esperanto         |


### PR DESCRIPTION
Idiomatic OE uses the same particle ('tha') for 'when' and 'then', occasionally but not always 'tha' for 'when' and 'tha the' for 'then'.

The 7 for 'ond' is as close as a modern typeface gets to the Tironian note for 'et', often used as an abbreviation for 'ond' in OE manuscripts.
