### PR TITLE
fixed IndexOutOfBoundsException in gherkin java support

### DIFF
--- a/java/src/main/java/gherkin/formatter/PrettyFormatter.java
+++ b/java/src/main/java/gherkin/formatter/PrettyFormatter.java
@@ -137,9 +137,17 @@ public class PrettyFormatter implements Reporter, Formatter {
         statement = null;
     }
 
+    private int popIndentation() {
+        return indentations.isEmpty() ? 0 : indentations.remove(0);
+    }
+
+    private int getIndentation() {
+        return indentations.isEmpty() ? 0 : indentations.get(0);
+    }
+
     private String indentedLocation(String location, boolean proceed) {
         StringBuilder sb = new StringBuilder();
-        int indentation = proceed ? indentations.remove(0) : indentations.get(0);
+        int indentation = proceed ? popIndentation() : getIndentation();
         if (location == null) {
             return "";
         }


### PR DESCRIPTION
This bug manifested itself in cucumber-jvm when running against
  a feature with no steps implemented yet.  It looked like this
  in the maven output:

  Scenario: Say hello                     # cucumber/examples/java/helloworld/helloworld.feature:3
    Given I have a hello app with "Howdy"
    When I ask it to say hi    When I ask it to say hiTests run: 3, Failures: 0, Errors: 2, Skipped: 1, Time elapsed: 0.56 sec <<< FAILURE!
Feature: Hello World  Time elapsed: 0.014 sec  <<< ERROR!
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
    at java.util.ArrayList.rangeCheck(ArrayList.java:604)
    at java.util.ArrayList.get(ArrayList.java:382)
    at gherkin.formatter.PrettyFormatter.indentedLocation(PrettyFormatter.java:142)
    at gherkin.formatter.PrettyFormatter.printStep(PrettyFormatter.java:255)
    at gherkin.formatter.PrettyFormatter.match(PrettyFormatter.java:179)
    ...
