### PR TITLE
Add German plural form of "Given"

### DIFF
--- a/lib/gherkin/i18n.json
+++ b/lib/gherkin/i18n.json
@@ -119,7 +119,7 @@
 	  "scenario": "Szenario",
 	  "scenario_outline": "Szenariogrundriss",
 	  "examples": "Beispiele",
-	  "given": "*|Angenommen|Gegeben sei",
+	  "given": "*|Angenommen|Gegeben sei|Gegeben seien",
 	  "when": "*|Wenn",
 	  "then": "*|Dann",
 	  "and": "*|Und",


### PR DESCRIPTION
The English

> Given two words a and b

would be rendered in German

> Gegeben seien zwei Wörter a und b

Currently Gherkin/Cucumber supports only the singular form "Gegeben sei".
