### PR TITLE
fix for dissapearing examples tags

### DIFF
--- a/lib/gherkin/formatter/filter_formatter.rb
+++ b/lib/gherkin/formatter/filter_formatter.rb
@@ -130,7 +130,7 @@ module Gherkin
         end
 
         @examples_events.clear
-        @examples_tags.clear
+        @examples_tags = []
         @examples_name = nil
         @examples_range = nil
       end


### PR DESCRIPTION
The filter_formatter is clearing examples tags. Array.clear ends up clearing the objects in the array, which happens to be the same object that is still available to Examples#tags. Instead we just want to clear out @examples_tags for FilterFormatter.

I'm firing off this PR out before writing a new test. Also, I assume @examples_events should be handled the same way, but I'll come back to this soon if no one beats me to it.
