### PR TITLE
fixed encoding issues in js gherkin

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 ## [Git master](https://github.com/cucumber/gherkin/compare/v2.12.1...master)
 
 * Java JSONFormatter should record before hooks in next scenario ([#270](https://github.com/cucumber/gherkin/pull/270) Björn Rasmusson)
+* [JavaScript] Fix encoding issues ([#272](https://github.com/cucumber/gherkin/pull/272) Lukas Degener, Thorsten Glaser)
 
 ## [2.12.1](https://github.com/cucumber/gherkin/compare/v2.12.0...v2.12.1)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
 Copyright (c) 2009-2013 Mike Sassak, Gregory Hnatiuk, Aslak Hellesøy
-Copyright (c) 2013 Lukas Degener, Thorsten Glaser
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/ragel/lexer.js.rl.erb
+++ b/ragel/lexer.js.rl.erb
@@ -165,10 +165,10 @@ Lexer.prototype.scan = function(data) {
 };
 
 
-/* 
+/*
  * Decode utf-8 byte sequence to string.
  */
-var decodeUtf8 = function(bytes){
+var decodeUtf8 = function(bytes) {
   var result = "";
   var i = 0;
   var wc;
@@ -220,14 +220,14 @@ var decodeUtf8 = function(bytes){
 
 /*
  * Encode string to an array of bytes using utf8 encoding.
- * 
+ *
  * Javascript internally stores character data as utf16 (like java).
  * String.charCodeAt() does *not* produce unicode points, but simply
  * reflects this internal representation. Thus, it is necessary
  * to first decode the utf-16 representation before encoding to
  * utf-8.
  */
-var encodeUtf8 = function(string){
+var encodeUtf8 = function(string) {
   var bytes = [];
   var i = 0;
   var j = 0;
@@ -273,8 +273,6 @@ Lexer.prototype.bytesToString = function(bytes) {
   }
   return decodeUtf8(bytes);
 };
-
-
 
 Lexer.prototype.stringToBytes = function(string) {
   return encodeUtf8(string);


### PR DESCRIPTION
Hi, this should fix #225, please refer there for details.

I added a simple testcase for the generated JS-Lexer, see js/test/test.de.js.

This is my very first github contribution, please let me know if I messed up anything.
