### PR TITLE
Durations are Longs not longs as they are optional

### DIFF
--- a/java/src/main/java/gherkin/JSONParser.java
+++ b/java/src/main/java/gherkin/JSONParser.java
@@ -212,7 +212,7 @@ public class JSONParser {
         return getString(r, "status");
     }
 
-    private long duration(Map r) {
+    private Long duration(Map r) {
         return getLong(r, "duration");
     }
 


### PR DESCRIPTION
The model already treats the Duration as a Long but the parser insitst its a long causing Longs to be unboxed and then re-boxed.
if the duration is missing (as the result is skipped) then this causes a null pointer exception trying to parse the json.
