### PR TITLE
Expose ID so that tools can differentiate between runs of scenario exampls

### DIFF
--- a/java/src/main/java/gherkin/formatter/model/TagStatement.java
+++ b/java/src/main/java/gherkin/formatter/model/TagStatement.java
@@ -18,6 +18,10 @@ public abstract class TagStatement extends DescribedStatement {
         return tags;
     }
 
+    public String getId() {
+        return id;
+    }
+
     @Override
     protected Integer getFirstNonCommentLine() {
         if (getTags().isEmpty()) {


### PR DESCRIPTION
The ID identifies a run (e.g. one run of a ScenarioExample from another) however tools are not able to use this as the field is private and there is no getter.

Beacuse of this they can not distinguish one run of a scenario example from another.

This simply expsoses the ID so that tools can use this to uniquely identify an invocation of the scenario example.
