### PR TITLE
Relax the tests of the listing of available languages.

### DIFF
--- a/java/src/test/java/gherkin/I18nTest.java
+++ b/java/src/test/java/gherkin/I18nTest.java
@@ -1,15 +1,22 @@
 package gherkin;
 
+import gherkin.deps.com.google.gson.reflect.TypeToken;
+import gherkin.deps.com.google.gson.Gson;
 import gherkin.util.Mapper;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static gherkin.util.FixJava.map;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class I18nTest {
     @Test
@@ -21,7 +28,14 @@ public class I18nTest {
                 return i18n.getIsoCode();
             }
         });
-        assertEquals(asList("af,ar,bg,bm,ca,cs,cy-GB,da,de,el,en,en-Scouse,en-au,en-lol,en-old,en-pirate,en-tx,eo,es,et,fa,fi,fr,gl,he,hi,hr,ht,hu,id,is,it,ja,jv,kn,ko,lt,lu,lv,nl,no,pa,pl,pt,ro,ru,sk,sl,sr-Cyrl,sr-Latn,sv,th,tl,tlh,tr,tt,uk,uz,vi,zh-CN,zh-TW".split(",")), isoCodes);
+        Map<String, Map<String, String>> i18nContent =
+                new Gson().fromJson(new InputStreamReader(I18n.class.getResourceAsStream("/gherkin/i18n.json"), "UTF-8"), new TypeToken<Map<String, Map<String, String>>>() {}.getType());
+        List<String> i18nContentKeys = extractSortedListOfMapKeys(i18nContent);
+
+        assertEquals(i18nContentKeys, isoCodes);
+        assertThat(isoCodes, hasItem("ar"));
+        assertThat(isoCodes, hasItem("en"));
+        assertThat(isoCodes, hasItem("zh-TW"));
     }
 
     @Test
@@ -64,5 +78,12 @@ public class I18nTest {
         I18n tlh = new I18n("tlh");
         assertEquals(Arrays.asList("* ", "ghu' noblu' ", "DaH ghu' bejlu' "), tlh.keywords("given"));
         assertEquals("tlh", tlh.getLocale().getLanguage());
+    }
+
+    private List<String> extractSortedListOfMapKeys(Map<String, ?> map) {
+        String[] emptyStringArray = {};
+        List<String> keys = asList(map.keySet().toArray(emptyStringArray));
+        Collections.sort(keys);
+        return keys;
     }
 }

--- a/spec/gherkin/i18n_spec.rb
+++ b/spec/gherkin/i18n_spec.rb
@@ -1,5 +1,6 @@
 #encoding: utf-8
 require 'spec_helper'
+require 'multi_json'
 
 module Gherkin
   module Lexer
@@ -184,70 +185,26 @@ module Gherkin
           Gherkin::I18n.keyword_regexp(:step).should =~ /\|Quando \|Quand \|Quan \|Pryd \|/
         end
 
-        it "should print available languages" do
-          ("\n" + Gherkin::I18n.language_table).should == %{
-      | af        | Afrikaans           | Afrikaans         |
+        it "should include Arabic, English and Chinese traditional in the language table" do 
+          language_table = "\n" + Gherkin::I18n.language_table
+          language_table.should include(%{
       | ar        | Arabic              | العربية           |
-      | bg        | Bulgarian           | български         |
-      | bm        | Malay               | Bahasa Melayu     |
-      | ca        | Catalan             | català            |
-      | cs        | Czech               | Česky             |
-      | cy-GB     | Welsh               | Cymraeg           |
-      | da        | Danish              | dansk             |
-      | de        | German              | Deutsch           |
-      | el        | Greek               | Ελληνικά          |
+})
+          language_table.should include(%{
       | en        | English             | English           |
-      | en-Scouse | Scouse              | Scouse            |
-      | en-au     | Australian          | Australian        |
-      | en-lol    | LOLCAT              | LOLCAT            |
-      | en-old    | Old English         | Englisc           |
-      | en-pirate | Pirate              | Pirate            |
-      | en-tx     | Texan               | Texan             |
-      | eo        | Esperanto           | Esperanto         |
-      | es        | Spanish             | español           |
-      | et        | Estonian            | eesti keel        |
-      | fa        | Persian             | فارسی             |
-      | fi        | Finnish             | suomi             |
-      | fr        | French              | français          |
-      | gl        | Galician            | galego            |
-      | he        | Hebrew              | עברית             |
-      | hi        | Hindi               | हिंदी             |
-      | hr        | Croatian            | hrvatski          |
-      | ht        | Creole              | kreyòl            |
-      | hu        | Hungarian           | magyar            |
-      | id        | Indonesian          | Bahasa Indonesia  |
-      | is        | Icelandic           | Íslenska          |
-      | it        | Italian             | italiano          |
-      | ja        | Japanese            | 日本語               |
-      | jv        | Javanese            | Basa Jawa         |
-      | kn        | Kannada             | ಕನ್ನಡ             |
-      | ko        | Korean              | 한국어               |
-      | lt        | Lithuanian          | lietuvių kalba    |
-      | lu        | Luxemburgish        | Lëtzebuergesch    |
-      | lv        | Latvian             | latviešu          |
-      | nl        | Dutch               | Nederlands        |
-      | no        | Norwegian           | norsk             |
-      | pa        | Panjabi             | ਪੰਜਾਬੀ            |
-      | pl        | Polish              | polski            |
-      | pt        | Portuguese          | português         |
-      | ro        | Romanian            | română            |
-      | ru        | Russian             | русский           |
-      | sk        | Slovak              | Slovensky         |
-      | sl        | Slovenian           | Slovenski         |
-      | sr-Cyrl   | Serbian             | Српски            |
-      | sr-Latn   | Serbian (Latin)     | Srpski (Latinica) |
-      | sv        | Swedish             | Svenska           |
-      | th        | Thai                | ไทย               |
-      | tl        | Telugu              | తెలుగు            |
-      | tlh       | Klingon             | tlhIngan          |
-      | tr        | Turkish             | Türkçe            |
-      | tt        | Tatar               | Татарча           |
-      | uk        | Ukrainian           | Українська        |
-      | uz        | Uzbek               | Узбекча           |
-      | vi        | Vietnamese          | Tiếng Việt        |
-      | zh-CN     | Chinese simplified  | 简体中文              |
+})
+          language_table.should include(%{
       | zh-TW     | Chinese traditional | 繁體中文              |
-}
+})
+        end
+
+        it "should print available languages" do
+          languages = MultiJson.load(File.open(File.dirname(__FILE__) + '/../../lib/gherkin/i18n.json', 'r:utf-8').read).keys
+          language_table = Gherkin::I18n.language_table
+          language_table.lines.count.should == languages.count
+          for language in languages do
+            ("\n" + language_table).should include("\n      | " + language + " ")
+          end
         end
 
         it "should print keywords for a given language" do


### PR DESCRIPTION
Currently language list/language table is hard coded in tests which makes it unnecessarily hard to add new languages (see [comment-1](https://github.com/cucumber/gherkin/pull/296#issuecomment-35805164) and [comment-2](https://github.com/cucumber/gherkin/pull/290#issuecomment-35842201))

Therefore, to simplify the addition of new languages, remove the hard coded language list/language table in the tests. Instead test a sample of languages in addition to having the tests read the list of language codes from the file [i18n.json](https://github.com/cucumber/gherkin/blob/master/lib/gherkin/i18n.json)
