### PR TITLE
Byte Order Mark removal if detected

### DIFF
--- a/ragel/lexer.js.rl.erb
+++ b/ragel/lexer.js.rl.erb
@@ -151,8 +151,8 @@ Lexer.prototype.scan = function(data) {
   } else if(typeof Buffer != 'undefined' && Buffer.isBuffer(data)) {
     // Node.js
     // Check for Byte Order Mark
-    if (data[0] === 239 && data[1] === 187 && data[2] === 191) {
-        data = data.slice(3, data.length);
+    if (data[0] === 0xEF && data[1] === 0xBE && data[2] === 0xBB) {
+        data = data.slice(3);
     }
     var buf = new Buffer(data.length + ending.length);
     data.copy(buf, 0, 0);


### PR DESCRIPTION
Hi, I have finally managed to add a detection check of a Byte Order Mark before processing the file/string with the javascript lexer.

I have tested locally and it seems to work fine with _cucumber-js_. I can't find the ignored test for BOM, to enable it again and see if everything works well. I could write a new test if this is missing.
