### PR TITLE
change regexp matchin Ruby versions to support Ruby2.1

### DIFF
--- a/lib/gherkin/formatter/pretty_formatter.rb
+++ b/lib/gherkin/formatter/pretty_formatter.rb
@@ -199,7 +199,7 @@ module Gherkin
         end
       end
 
-      if(RUBY_VERSION =~ /^1\.9|2\.0/)
+      if(RUBY_VERSION =~ /^(1\.9|2\.)/)
         START = /#{'^'.encode('UTF-8')}/
         TRIPLE_QUOTES = /#{'"""'.encode('UTF-8')}/
       else

--- a/ragel/lexer.rb.rl.erb
+++ b/ragel/lexer.rb.rl.erb
@@ -165,7 +165,7 @@ module Gherkin
         utf8_pack(rest[0..rest.index(10)||-1]).strip # 10 is \n
       end
 
-      if (RUBY_VERSION =~ /^1\.9|2\.0/)
+      if (RUBY_VERSION =~ /^(1\.9|2\.)/)
         def utf8_pack(array)
           array.pack("c*").force_encoding("UTF-8")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ def silence_warnings(&block)
   result
 end
 
-if RUBY_VERSION =~ /1\.9|2\.0/
+if RUBY_VERSION =~ /^(1\.9|2\.)/
   silence_warnings do
     Encoding.default_external = Encoding::UTF_8
     Encoding.default_internal = Encoding::UTF_8


### PR DESCRIPTION
The regexp now matches 1.9.x and 2.x versions of Ruby MRI. This makes gherkin support Ruby2.1 and fixes test issues described in https://github.com/cucumber/gherkin/issues/305.
