### PR TITLE
RCov is not supported anymore for recent ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_install: gem install bundler -v 1.3.5
+before_install: gem install bundler -v 1.11.2
 rvm: 
   - 2.0.0
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_install: gem install bundler -v 1.11.2
+before_install: gem install bundler -v 1.7.6
 rvm: 
   - 2.0.0
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_install: gem install bundler -v 1.7.6
+before_install: gem install bundler -v 1.11.2
 rvm: 
   - 2.0.0
   - 1.9.3

--- a/tasks/cucumber.rake
+++ b/tasks/cucumber.rake
@@ -9,12 +9,6 @@ Cucumber::Rake::Task.new(:cucumber) do |t|
 end
 
 namespace :cucumber do
-  Cucumber::Rake::Task.new(:rcov, "Run Cucumber using RCov") do |t|
-    t.cucumber_opts = "--profile default"
-    t.rcov = RUBY_VERSION =~ /^1\.8/
-    t.rcov_opts = %w{--exclude spec\/}
-  end
-
   Cucumber::Rake::Task.new(:native_lexer, "Run Native lexer Cucumber features") do |t|
     t.cucumber_opts = "--profile native_lexer"
   end


### PR DESCRIPTION
Removing Rcov from rake task as it causes a build to break. Given @aslakhellesoy is working on gherkin3 there is not much point fixing this. 

The only reason I am raising this pull request is to build current version of gherkin which fixes propagating tags in example groups to Before hooks in cucumber-jvm.
